### PR TITLE
SpanJson Minify

### DIFF
--- a/benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="SpanJson" Version="2.0.4" />
+    <PackageReference Include="SpanJson" Version="2.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/benchmarks/MinifyBenchmarks.cs
+++ b/benchmarks/MinifyBenchmarks.cs
@@ -42,5 +42,23 @@ namespace Benchmarks
             // let's benchmark string API.
             return JObject.Parse(json).ToString(Newtonsoft.Json.Formatting.None);
         }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(TestData))]
+        public string SpanJsonUtf16(byte[] jsonData, string fileName, string fileSize)
+        {
+            string json = Encoding.UTF8.GetString(jsonData);
+            // let's benchmark string API.
+            return SpanJson.JsonSerializer.Minifier.Minify(json);
+        }
+
+
+        [Benchmark]
+        [ArgumentsSource(nameof(TestData))]
+        public byte[] SpanJsonUtf8(byte[] jsonData, string fileName, string fileSize)
+        {
+            // let's benchmark string API.
+            return SpanJson.JsonSerializer.Minifier.Minify(jsonData);
+        }
     }
 }


### PR DESCRIPTION
PR with Minify support in SpanJson. I add both APIs the one which converts the byte[] to string and uses the utf16 api to minify and doing with the byte-array directly.
I don't know why your API actually does minification with string output, but I basically did the same for the benchmarks. If you compare both SpanJson versions, you see basically the overhead of Utf8->String there. As for performance, the larger the data gets the more difference is visible, as expected.
The JSON.NET benchmark for github_events.json fails, because JObject can't handle Arrays and that one starts with an array. "Newtonsoft.Json.JsonReaderException: Error reading JObject from JsonReader. Current JsonReader item is not an object: StartArray. Path '', line 1, position 1."

I actually found a bug in SpanJson with the apache_builds.json, SpanJson didn't handle spaces after the name and before the colon properly, e.g. {"Key" : "Value"} failed, while {"Key": "Value"} was valid.

``` ini

BenchmarkDotNet=v0.11.4, OS=Windows 10.0.17763.316 (1809/October2018Update/Redstone5)
Intel Core i9-9900K CPU 3.60GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.0.100-preview4-010530
  [Host] : .NET Core 3.0.0-preview4-27426-2 (CoreCLR 4.6.27426.71, CoreFX 4.7.19.12302), 64bit RyuJIT
  Core   : .NET Core 3.0.0-preview4-27426-2 (CoreCLR 4.6.27426.71, CoreFX 4.7.19.12302), 64bit RyuJIT

Job=Core  EnvironmentVariables=COMPlus_TieredCompilation=1  Runtime=Core  

```
|                     Method |      jsonData |           fileName |    fileSize |          Mean |         Error |        StdDev |        Median | Ratio | RatioSD |
|--------------------------- |-------------- |------------------- |------------ |--------------:|--------------:|--------------:|--------------:|------:|--------:|
| **_SimdJsonWithoutValidation** | **System.Byte[]** | **apache_builds.json** |   **127,28 Kb** |     **174.61 us** |     **3.3832 us** |     **3.1646 us** |     **175.57 us** |  **1.00** |    **0.00** |
|                  _SimdJson | System.Byte[] | apache_builds.json |   127,28 Kb |     274.74 us |     5.3864 us |     6.2029 us |     275.35 us |  1.57 |    0.04 |
|                    JsonNet | System.Byte[] | apache_builds.json |   127,28 Kb |   1,598.31 us |    11.1974 us |    10.4740 us |   1,594.05 us |  9.16 |    0.19 |
|              SpanJsonUtf16 | System.Byte[] | apache_builds.json |   127,28 Kb |     291.09 us |     1.2649 us |     1.1832 us |     291.53 us |  1.67 |    0.03 |
|               SpanJsonUtf8 | System.Byte[] | apache_builds.json |   127,28 Kb |     219.31 us |     0.8234 us |     0.7300 us |     219.42 us |  1.26 |    0.02 |
|                            |               |                    |             |               |               |               |               |       |         |
| **_SimdJsonWithoutValidation** | **System.Byte[]** |        **canada.json** | **2.251,05 Kb** |   **3,472.76 us** |    **46.5033 us** |    **41.2240 us** |   **3,475.83 us** |  **1.00** |    **0.00** |
|                  _SimdJson | System.Byte[] |        canada.json | 2.251,05 Kb |   6,794.82 us |    27.8295 us |    24.6702 us |   6,789.97 us |  1.96 |    0.02 |
|                    JsonNet | System.Byte[] |        canada.json | 2.251,05 Kb | 175,631.10 us | 3,502.1400 us | 4,429.0857 us | 174,123.07 us | 50.52 |    1.35 |
|              SpanJsonUtf16 | System.Byte[] |        canada.json | 2.251,05 Kb |  12,972.73 us |   252.1864 us |   407.2341 us |  13,027.41 us |  3.79 |    0.10 |
|               SpanJsonUtf8 | System.Byte[] |        canada.json | 2.251,05 Kb |   9,131.91 us |   167.3539 us |   156.5430 us |   9,189.92 us |  2.63 |    0.05 |
|                            |               |                    |             |               |               |               |               |       |         |
| **_SimdJsonWithoutValidation** | **System.Byte[]** |  **citm_catalog.json** | **1.727,20 Kb** |   **2,659.59 us** |    **87.2437 us** |   **255.8706 us** |   **2,759.98 us** |  **1.00** |    **0.00** |
|                  _SimdJson | System.Byte[] |  citm_catalog.json | 1.727,20 Kb |   3,450.29 us |    50.7684 us |    47.4888 us |   3,453.08 us |  1.62 |    0.07 |
|                    JsonNet | System.Byte[] |  citm_catalog.json | 1.727,20 Kb |  37,398.02 us |   728.2027 us |   866.8735 us |  37,642.76 us | 16.85 |    1.40 |
|              SpanJsonUtf16 | System.Byte[] |  citm_catalog.json | 1.727,20 Kb |   4,499.79 us |    27.1933 us |    24.1062 us |   4,499.87 us |  2.13 |    0.05 |
|               SpanJsonUtf8 | System.Byte[] |  citm_catalog.json | 1.727,20 Kb |   3,426.38 us |    25.6821 us |    24.0231 us |   3,431.14 us |  1.61 |    0.06 |
|                            |               |                    |             |               |               |               |               |       |         |
| **_SimdJsonWithoutValidation** | **System.Byte[]** | **github_events.json** |    **65,13 Kb** |      **99.76 us** |     **1.8584 us** |     **1.8252 us** |      **99.83 us** |  **1.00** |    **0.00** |
|                  _SimdJson | System.Byte[] | github_events.json |    65,13 Kb |     170.03 us |     5.0910 us |    15.0111 us |     176.64 us |  1.39 |    0.04 |
|                    JsonNet | System.Byte[] | github_events.json |    65,13 Kb |            NA |            NA |            NA |            NA |     ? |       ? |
|              SpanJsonUtf16 | System.Byte[] | github_events.json |    65,13 Kb |     156.58 us |     1.9325 us |     1.8077 us |     156.88 us |  1.57 |    0.04 |
|               SpanJsonUtf8 | System.Byte[] | github_events.json |    65,13 Kb |     108.69 us |     0.8318 us |     0.7781 us |     108.53 us |  1.09 |    0.03 |

Benchmarks with issues:
  MinifyBenchmarks.JsonNet: Core(EnvironmentVariables=COMPlus_TieredCompilation=1, Runtime=Core) [jsonData=System.Byte[], fileName=github_events.json, fileSize=65,13 Kb]
