### PR TITLE
Avoid some bounds checks

### DIFF
--- a/src/Utils/Utils.cs
+++ b/src/Utils/Utils.cs
@@ -50,8 +50,11 @@ namespace SimdJsonSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint32_t is_not_structural_or_whitespace(uint8_t c)
         {
-            // bounds checks :(
-            return structural_or_whitespace_negated[c];
+            // Bypass bounds check as c can never 
+            // exceed the bounds of structural_or_whitespace_negated
+            return Unsafe.AddByteOffset(
+                ref MemoryMarshal.GetReference(structural_or_whitespace_negated), 
+                (IntPtr)c);
         }
 
         private static ReadOnlySpan<byte> structural_or_whitespace => new byte[256] {
@@ -70,8 +73,11 @@ namespace SimdJsonSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint32_t is_structural_or_whitespace(uint8_t c)
         {
-            // bounds checks :(
-            return structural_or_whitespace[c];
+            // Bypass bounds check as c can never 
+            // exceed the bounds of structural_or_whitespace
+            return Unsafe.AddByteOffset(
+                ref MemoryMarshal.GetReference(structural_or_whitespace), 
+                (IntPtr)c);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Utils/numberparsing.cs
+++ b/src/Utils/numberparsing.cs
@@ -4,6 +4,7 @@
 #define SWAR_NUMBER_PARSING
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
@@ -124,7 +125,11 @@ namespace SimdJsonSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool is_not_structural_or_whitespace_or_exponent_or_decimal(unsigned_bytechar c)
         {
-            return structural_or_whitespace_or_exponent_or_decimal_negated[c] == 1;
+            // Bypass bounds check as c can never 
+            // exceed the bounds of structural_or_whitespace_or_exponent_or_decimal_negated
+            return Unsafe.AddByteOffset(
+                ref MemoryMarshal.GetReference(structural_or_whitespace_or_exponent_or_decimal_negated),
+                (IntPtr)c) == 1;
         }
 
         // check quickly whether the next 8 chars are made of digits

--- a/src/Utils/stringparsing.Sse2.cs
+++ b/src/Utils/stringparsing.Sse2.cs
@@ -120,7 +120,7 @@ namespace SimdJsonSharp
                         // write bs_dist+1 characters to output
                         // note this may reach beyond the part of the buffer we've actually
                         // seen. I think this is ok
-                        uint8_t escape_result = escape_map[escape_char];
+                        uint8_t escape_result = escape(escape_char);
                         if (escape_result == 0)
                         {
 #if JSON_TEST_STRINGS // for unit testing

--- a/src/Utils/stringparsing.cs
+++ b/src/Utils/stringparsing.cs
@@ -3,9 +3,10 @@
 
 #define CHECKUNESCAPED
 using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
-using System.Runtime.CompilerServices;
 
 #region stdint types and friends
 // if you change something here please change it in other files too
@@ -50,6 +51,16 @@ namespace SimdJsonSharp
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint8_t escape(uint8_t c)
+        {
+            // Bypass bounds check as c can never 
+            // exceed the bounds of escape_map
+            return Unsafe.AddByteOffset(
+               ref MemoryMarshal.GetReference(escape_map),
+               (IntPtr)c);
+        }
 
         // handle a unicode codepoint
         // write appropriate values into dest
@@ -209,7 +220,7 @@ namespace SimdJsonSharp
                         // write bs_dist+1 characters to output
                         // note this may reach beyond the part of the buffer we've actually
                         // seen. I think this is ok
-                        uint8_t escape_result = escape_map[escape_char];
+                        uint8_t escape_result = escape(escape_char);
                         if (escape_result == 0)
                         {
 #if JSON_TEST_STRINGS // for unit testing


### PR DESCRIPTION
Drops some array bounds checks.
Run the following benchmark to compare asm:
<details>
 <summary>Benchmark Source</summary>

```csharp
    [DisassemblyDiagnoser]
    [ShortRunJob]
    public class Program
    {
        private static ReadOnlySpan<byte> Data => new byte[8] 
        {
            1,2,3,4,5,6,7,8
        };

        public IEnumerable<int> Param()
        {
            yield return 1;
        }

        [Benchmark]
        [ArgumentsSource(nameof(Param))]
        public int AccessNoBoundsChekcs(byte c)
        {
            return Unsafe.AddByteOffset(ref MemoryMarshal.GetReference(Data), (IntPtr)c);
        }

        [Benchmark]
        [ArgumentsSource(nameof(Param))]
        public int AccessBoundsChekcs(byte c)
        {
            return Data[c];
        }

        static void Main()
        {
            BenchmarkRunner.Run<Program>();
        }
    }
```

</details>