### PR TITLE
Improve code generated by is_integer

### DIFF
--- a/src/Utils/numberparsing.cs
+++ b/src/Utils/numberparsing.cs
@@ -102,7 +102,7 @@ namespace SimdJsonSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool is_integer(bytechar c)
         {
-            return (c - '0') <= '9' - '0';
+            return (uint8_t)(c - '0') <= 9;
         }
 
         private static ReadOnlySpan<byte> structural_or_whitespace_or_exponent_or_decimal_negated => new byte[256]

--- a/src/Utils/numberparsing.cs
+++ b/src/Utils/numberparsing.cs
@@ -102,9 +102,7 @@ namespace SimdJsonSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool is_integer(bytechar c)
         {
-            return (c >= (bytechar) '0' && c <= (bytechar) '9');
-            // this gets compiled to (uint8_t)(c - '0') <= 9 on all decent compilers
-            //return (uint8_t) (c - '0') <= 9;
+            return (c - '0') <= '9' - '0';
         }
 
         private static ReadOnlySpan<byte> structural_or_whitespace_or_exponent_or_decimal_negated => new byte[256]


### PR DESCRIPTION
Another small one... (guess that comment by lemire does not apply to Roslyn)

Changes asm from 
```
    L0000: movsx edx, cl
    L0003: cmp edx, 0x30
    L0006: jl L0012
    L0008: cmp edx, 0x39
    L000b: setle al
    L000e: movzx eax, al
    L0011: ret
    L0012: xor eax, eax
    L0014: ret
```
to
```
    L0000: movsx ecx, cl
    L0003: add ecx, 0xffffffd0
    L0006: and ecx, 0xff
    L000c: cmp ecx, 0x9
    L000f: setle al
    L0012: movzx eax, al
    L0015: ret
```

We could even get rid of the `movsx` (sign extension) if the argument was `byte` insted of `sbyte` by casting the LHS to `uint`. I am however not sure whether changing the argument in all the call sites would be profitable/possible.. so I went for the low hanging fruit.